### PR TITLE
activate cmcd report

### DIFF
--- a/src/html/options.html
+++ b/src/html/options.html
@@ -67,6 +67,18 @@
                 <input type="checkbox" id="video-native-mode">
                 </label>
         </p>
+        <p>
+            <label for="cmcd">
+                enable cmcd:
+                <input type="checkbox" id="cmcd">
+            </label>
+        </p>
+        <p>
+            <label for="cmcd-use-header">
+                send cmcd as header:
+                <input type="checkbox" id="cmcd-use-header">
+            </label>
+        </p>
         <button id="saveSettings">Save</button>
         <span id="status"></span>
     </body>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -24,6 +24,8 @@ var hasplayerjs_loaded = false;
 var maxQuality = false;
 
 var video_native_mode = false;
+var cmcd_enable = false;
+var cmcd_use_header = false;
 var player_tech = null;
 var playlist = new Playlist();
 
@@ -475,12 +477,16 @@ function restoreSettings() {
         use_latest_hasplayerjs: true,
         debug: false,
         video_native_mode: false,
+        cmcd_enable: false,
+        cmcd_use_header: false,
         maxQuality: false,
         user_volume: .5,
     }, function(settings) {
         debug = settings.debug;
         maxQuality = settings.maxQuality;
         video_native_mode = settings.video_native_mode;
+        cmcd_enable = settings.cmcd_enable;
+        cmcd_use_header = settings.cmcd_use_header;
         user_volume = settings.user_volume;
 
         if(settings.use_latest_hlsjs) {

--- a/src/js/options.js
+++ b/src/js/options.js
@@ -40,6 +40,9 @@ function save_options() {
     var maxQuality = document.getElementById('maxQuality').checked;
     var video_native_mode = document.getElementById('video-native-mode').checked;
 
+    var cmcd_enable = document.getElementById("cmcd").checked;
+    var cmcd_use_header = document.getElementById("cmcd-use-header").checked;
+
     chrome.storage.local.set({
         hlsjs_version: hlsjs_version,
         dashjs_version: dashjs_version,
@@ -49,7 +52,9 @@ function save_options() {
         use_latest_hasplayerjs: use_latest_hasplayerjs,
         debug: dbg,
         maxQuality: maxQuality,
-        video_native_mode: video_native_mode
+        video_native_mode: video_native_mode,
+        cmcd_enable: cmcd_enable,
+        cmcd_use_header: cmcd_use_header
     }, function() {
         var status = document.getElementById('status');
         status.textContent = 'Options saved.';
@@ -69,7 +74,9 @@ function restore_options() {
         use_latest_hasplayerjs: true,
         debug: false,
         maxQuality: false,
-        video_native_mode: false
+        video_native_mode: false,
+        cmcd_enable: false,
+        cmcd_use_header: false
     }, function(items) {
         console.log(items);
 
@@ -103,6 +110,9 @@ function restore_options() {
         document.getElementById('cbDebug').checked = items.debug;
         document.getElementById('maxQuality').checked = items.maxQuality;
         document.getElementById('video-native-mode').checked = items.video_native_mode;
+
+        document.getElementById("cmcd").checked = items.cmcd_enable;
+        document.getElementById("cmcd-use-header").checked = items.cmcd_use_header;
     });
 }
 

--- a/src/js/player/hls_tech.js
+++ b/src/js/player/hls_tech.js
@@ -4,7 +4,7 @@ var HlsTech = function(options) {
     var _hls_tech = this;
     this.is_live = false;
 
-    this.player = new Hls({
+    var config = {
         enableWorker: false,
         debug: options.debug,
 
@@ -13,7 +13,15 @@ var HlsTech = function(options) {
                 xhr.setRequestHeader(header_name, _hls_tech.options.headers[header_name]);
             }
         }
-    });
+    };
+
+    if(options.cmcd_enable) {
+        config.cmcd = {
+            useHeaders: options.cmcd_use_header
+        }
+    }
+
+    this.player = new Hls(config);
 
     this.player.on(Hls.Events.MANIFEST_PARSED, function(event, data) {
         data.type = event;


### PR DESCRIPTION
To check status of playback, cmcd is very useful.
Both hls.js and dash.js support this. 
So, I add two checkbox for sending cmcd at option page .

* Screenshot

![options](https://github.com/Palethorn/native-adaptive-streaming/assets/7157873/feed5436-0e47-4dd6-9b42-b2b3cdf25e9b)

P.S.
Thank you for making this extension. This extension saves a lot of my time.